### PR TITLE
Add bind hooks for customizing rows and cells.

### DIFF
--- a/data-table-cell.html
+++ b/data-table-cell.html
@@ -37,6 +37,13 @@
           observer: '_columnChanged'
         },
 
+        beforeBind: {
+          type: Object,
+          value: function() {
+            return function(data, cell) {};
+          }
+        },
+
         _instance: {
           type: Object,
           computed: '_templatize(column, _templatizer)'
@@ -85,6 +92,9 @@
       },
 
       _bindData: function(instance, data) {
+        if (!this.header) {
+          this.beforeBind(data, this);
+        }
         instance.bind(data);
       },
 

--- a/data-table-row.html
+++ b/data-table-row.html
@@ -62,6 +62,8 @@
       },
 
       properties: {
+        beforeBind: Object,
+        bind: Object,
         header: Boolean,
         expanded: {
           type: Boolean,
@@ -79,6 +81,8 @@
         }
       },
 
+      observers: ['_bindChanged(bind, beforeBind)'],
+
       attached: function() {
         if (this.domHost && this.domHost.tagName === 'IRON-DATA-TABLE') {
           var id = this._static.id++;
@@ -94,6 +98,10 @@
             Polymer.dom(this.domHost).appendChild(this);
           }
         }
+      },
+
+      _bindChanged: function(data, beforeBind) {
+        beforeBind(data, this);
       },
 
       _onTap: function(e) {

--- a/demo/styling.html
+++ b/demo/styling.html
@@ -112,6 +112,45 @@
       </template>
     </demo-snippet>
 
+    <h3>Customizing Rows and Cells with Hooks</h3>
+    <demo-snippet>
+      <template>
+        <style is="custom-style">
+          #grid4 data-table-cell.index {
+            color: red;
+          }
+
+          #grid4 data-table-row.even {
+            background-color: #eee;
+          }
+        </style>
+        <template is="dom-bind" id="t1">
+          <iron-ajax url="users.json" last-response="{{users}}" auto></iron-ajax>
+          <iron-data-table id="grid4" items="[[users.results]]">
+            <data-table-column name="#" width="20px" flex="0">
+              <template>[[index]]</template>
+            </data-table-column>
+            <data-table-column name="First Name">
+              <template>
+                <div>[[item.user.name.first]]</div>
+              </template>
+            </data-table-column>
+            <data-table-column name="Last Name">
+              <template>[[item.user.name.last]]</template>
+            </data-table-column>
+          </iron-data-table>
+          <script>
+            document.querySelector('#grid4').beforeRowBind = function(data, row) {
+              row.toggleClass('even', data.index % 2 === 0);
+            }
+            document.querySelector('#grid4').beforeCellBind = function(data, cell) {
+              cell.toggleClass('index', cell.column.name === '#');
+            }
+          </script>
+        </template>
+      </template>
+    </demo-snippet>
+
     <h3>Flex Height</h3>
     <demo-snippet>
       <template>

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -177,10 +177,19 @@ inspired styles to your `iron-data-table`.
       <iron-list id="list" as="item" items="[[_cachedItems]]" on-scroll="_onVerticalScroll" selection-enabled="[[selectionEnabled]]" multi-selection="[[multiSelection]]" selected-item="{{selectedItem}}" on-selected-items-changed="_selectedItemsChanged">
         <template>
           <div class="item">
-            <data-table-row tabindex$="[[tabIndex]]" selected$="[[_isSelected(selected, selectedItems.inverted)]]" even$="[[!_isEven(index)]]" row-detail-template="[[rowDetail]]" details-enabled="[[detailsEnabled]]" expanded="[[_isExpanded(item, _expandedItems)]]" on-item-expanded="_itemExpanded" on-item-collapsed="_itemCollapsed">
+            <data-table-row tabindex$="[[tabIndex]]"
+                            selected$="[[_isSelected(selected, selectedItems.inverted)]]"
+                            bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]"
+                            before-bind="[[beforeRowBind]]"
+                            even$="[[!_isEven(index)]]"
+                            row-detail-template="[[rowDetail]]"
+                            details-enabled="[[detailsEnabled]]"
+                            expanded="[[_isExpanded(item, _expandedItems)]]"
+                            on-item-expanded="_itemExpanded"
+                            on-item-collapsed="_itemCollapsed">
               <data-table-checkbox hidden$="[[!multiSelection]]" checked="[[_isSelected(selected, selectedItems.inverted)]]"></data-table-checkbox>
               <template is="dom-repeat" items="[[columns]]" as="column" index-as="colIndex">
-                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]"></data-table-cell>
+                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]" before-bind="[[beforeCellBind]]"></data-table-cell>
               </template>
               <template is="dom-if" if="[[_isExpanded(item, _expandedItems)]]" on-dom-change="_updateSizeForItem">
                 <data-table-row-detail row-detail-template="[[rowDetail]]" bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]"></data-table-row-detail>
@@ -212,6 +221,36 @@ inspired styles to your `iron-data-table`.
       },
 
       properties: {
+
+        /**
+         * A function that is called before data is bound to a row cell.
+         * Can be used to customize the cell element depending on the data.
+         * #### Example:
+         * ```js
+         * function(data, cell) {
+         *   cell.toggleClass('custom', data.useCustomClass);
+         * }
+         * ```
+         */
+        beforeCellBind: {
+          type: Object,
+          value: function() {
+            return function(data, cell) {};
+          }
+        },
+
+        /**
+         * A function that is called before data is bound to a row.
+         * Can be used to customize the row element depending on the data.
+         * #### Example:
+         * ```js
+         * function(data, row) {
+         *   row.toggleClass('custom', data.useCustomClass);
+         * }
+         * ```
+         */
+        beforeRowBind: Object,
+
         /**
          * An array containing the items which will be stamped to the column template
          * instances.


### PR DESCRIPTION
Fixes #47 

Enables styling of `<data-table-row>` and `<data-table-cell>` elements directly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/58)

<!-- Reviewable:end -->
