### PR TITLE
Less debouncing and more snappiness

### DIFF
--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -435,7 +435,6 @@ inspired styles to your `iron-data-table`.
 
       observers: ['_itemsChanged(items.*)',
         '_sizeChanged(size)',
-        '_currentPageChanged(dataSource, _currentPage)',
         '_resetData(dataSource, filter.*, sortOrder.*)'
       ],
 
@@ -715,6 +714,7 @@ inspired styles to your `iron-data-table`.
         this.toggleClass("scrolled", this.$.list.scrollTop >= 1, this.$.header);
 
         this._currentPage = Math.max(0, Math.floor(this.$.list.scrollTop / this.$.list._physicalAverage / this.pageSize));
+        this._currentPageChanged(this.dataSource, this._currentPage);
       },
 
       /**

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -435,7 +435,8 @@ inspired styles to your `iron-data-table`.
 
       observers: ['_itemsChanged(items.*)',
         '_sizeChanged(size)',
-        '_resetData(dataSource, filter.*, sortOrder.*)'
+        '_resetData(dataSource)',
+        '_debounceThenResetData(filter.*, sortOrder.*)'
       ],
 
       created: function() {
@@ -592,15 +593,18 @@ inspired styles to your `iron-data-table`.
         }.bind(this));
       },
 
-      _resetData: function(dataSource, filter, sortOrder) {
+      _resetData: function(dataSource) {
         // Resetting scroll position and selection for consistency here. They are
         // both reset implicitly when a new _cachedItems is set to iron-list, but
         // that doesn't happen when size of the dataset changes only by a few items.
         this.clearSelection();
+        this.clearCache();
+        this.$.list.scrollToIndex(0);
+      },
 
+      _debounceThenResetData(filter, sortOrder) {
         this.debounce('reset', function() {
-          this.clearCache();
-          this.$.list.scrollToIndex(0);
+          this._resetData(this.dataSource);
         }.bind(this), 100);
       },
 
@@ -788,17 +792,15 @@ inspired styles to your `iron-data-table`.
           this.loading = true;
         }
 
-        this.debounce('loading', function() {
-          this._loadPage(dataSource, page);
+        this._loadPage(dataSource, page);
 
-          if (page + 1 < (this.size / this.pageSize)) {
-            this._loadPage(dataSource, page + 1);
-          }
+        if (page + 1 < (this.size / this.pageSize)) {
+          this._loadPage(dataSource, page + 1);
+        }
 
-          if (page > 0) {
-            this._loadPage(dataSource, page - 1);
-          }
-        }.bind(this), 100);
+        if (page > 0) {
+          this._loadPage(dataSource, page - 1);
+        }
       },
 
       _loadPage: function(dataSource, page) {


### PR DESCRIPTION
First of all, I'd just like to say iron-data-table is a beautiful thing. I love the concept of having an html template for each column.

Second, I just saw this today and I have no idea what I'm doing. I want to use `iron-data-table`, but I need it to be snappy. I saw several instances of 100ms debouncing inside `iron-data-table.html`, which would seem to cut back on snappiness. I made changes to update the `iron-list` synchronously when possible. 

Don't feel obligated to accept this pull-request. Chances are, I'm messing something up. I hope you might find some use in it as food for thought.

Upon making this change in my personal project, it seemed to aggravate [issue 68](https://github.com/Saulis/iron-data-table/issues/68) for reasons I cannot fathom.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/69)

<!-- Reviewable:end -->
