### PR TITLE
Extract selection handling from iron-list

### DIFF
--- a/array-datasource.js
+++ b/array-datasource.js
@@ -1,0 +1,65 @@
+function ArrayDataSource(arr) {
+  function _filter(items, filter) {
+    if (filter.length === 0) {
+      return items;
+    }
+
+    return Array.prototype.filter.call(items, function(item, index) {
+      for (var i = 0; i < filter.length; i++) {
+        var value = Polymer.Base.get(filter[i].path, item);
+        if (!filter[i].filter) {
+          continue;
+        } else if (!value || value.toString().toLowerCase().indexOf(filter[i].filter.toString().toLowerCase()) === -1) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  function _compare(a, b) {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  }
+
+  function _sort(items, sortOrder) {
+    if (!sortOrder || sortOrder.length === 0) {
+      return items;
+    }
+
+    var multiSort = function() {
+      return function(a, b) {
+        return sortOrder.map(function(sort) {
+          if (sort.direction === 'asc') {
+            return _compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
+          } else if (sort.direction === 'desc') {
+            return _compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
+          }
+          return 0;
+        }).reduce(function firstNonZeroValue(p, n) {
+          return p ? p : n;
+        }, 0);
+      };
+    };
+
+    // make sure a copy is used so that original array is unaffected.
+    return Array.prototype.sort.call(items.slice(0), multiSort(sortOrder));
+  }
+
+  return function(opts, cb, err) {
+    var filteredItems = _filter(arr, opts.filter);
+
+    var sortedItems = _sort(filteredItems, opts.sortOrder);
+
+    var start = opts.page * opts.pageSize;
+    var end = start + opts.pageSize;
+    var slice = sortedItems.slice(start, end);
+
+    cb(slice, filteredItems.length);
+  };
+}

--- a/data-table-checkbox.html
+++ b/data-table-checkbox.html
@@ -21,6 +21,10 @@
         display: none;
       }
 
+      :host(:focus) {
+        outline: none;
+      }
+
       #container {
         position: relative;
         box-sizing: border-box;

--- a/data-table-column.html
+++ b/data-table-column.html
@@ -269,7 +269,6 @@
           }
         };
       }
-
     });
   </script>
 </dom-module>

--- a/data-table-row.html
+++ b/data-table-row.html
@@ -57,22 +57,9 @@
     Polymer({
       is: 'data-table-row',
 
-      listeners: {
-        'tap': '_onTap'
-      },
-
       properties: {
         beforeBind: Object,
         bind: Object,
-        header: Boolean,
-        expanded: {
-          type: Boolean,
-          notify: false,
-          value: false,
-          reflectToAttribute: true
-        },
-
-        rowDetailTemplate: Object,
 
         _static: {
           type: Object,
@@ -80,7 +67,7 @@
         }
       },
 
-      observers: ['_bindChanged(bind, beforeBind)', '_expandedChanged(expanded, bind)'],
+      observers: ['_bindChanged(bind, beforeBind)'],
 
       attached: function() {
         if (this.domHost && this.domHost.tagName === 'IRON-DATA-TABLE') {
@@ -104,28 +91,6 @@
 
       _bindChanged: function(data, beforeBind) {
         beforeBind(data, this);
-      },
-
-      _onTap: function(e) {
-        // Prevent item selection if row itself is not focused. This means that
-        // an element inside the row has been focused.
-        // Mobile devices don't move focus from body unless it's an input element that is focused, so this element will never get focused.
-        if (!this.header && document.activeElement !== document.body && Polymer.dom(document.activeElement) !== Polymer.dom(this)) {
-          e.stopPropagation();
-        } else if (this.rowDetailTemplate && this.detailsEnabled) {
-            this.expanded = !this.expanded;
-        }
-      },
-
-      // events can be fired also without the detail object, where the handler
-      // can get it using e.model.item property, but we still need to make sure
-      // bind has been set before firing the events.
-      _expandedChanged: function(expanded, bind) {
-        if (expanded) {
-          this.fire('item-expanded', {item: bind.item});
-        } else {
-          this.fire('item-collapsed', {item: bind.item});
-        }
       }
     });
   </script>

--- a/demo/templates.html
+++ b/demo/templates.html
@@ -93,7 +93,7 @@
           </style>
           <paper-input label="Foo" value="{{foo}}"></paper-input>
           <iron-ajax url="users.json" last-response="{{users}}" auto></iron-ajax>
-          <iron-data-table items="[[users.results]]">
+          <iron-data-table selection-enabled items="[[users.results]]">
             <data-table-column name="First Name">
               <template>
                 <paper-input value="{{item.user.name.first}}"></paper-input>

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -116,10 +116,8 @@ inspired styles to your `iron-data-table`.
         overflow-x: auto;
         overflow-y: hidden;
         -webkit-overflow-scrolling: touch;
-
         /* Default height just to help users get started in making stuff visible.  */
         height: 400px;
-
         @apply(--iron-data-table);
       }
 
@@ -128,7 +126,6 @@ inspired styles to your `iron-data-table`.
         left: 0;
         top: 0;
         bottom: 0;
-
         display: flex;
         flex-direction: column;
       }
@@ -180,25 +177,16 @@ inspired styles to your `iron-data-table`.
         </data-table-row>
       </div>
 
-      <iron-list id="list" as="item" items="[[_cachedItems]]" on-scroll="_onVerticalScroll" selection-enabled="[[selectionEnabled]]" multi-selection="[[multiSelection]]" selected-item="{{selectedItem}}" on-selected-items-changed="_selectedItemsChanged">
+      <iron-list id="list" as="item" items="[[_cachedItems]]" on-scroll="_onVerticalScroll">
         <template>
           <div class="item">
-            <data-table-row tabindex$="[[tabIndex]]"
-                            selected$="[[_isSelected(selected, selectedItems.inverted)]]"
-                            bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]"
-                            before-bind="[[beforeRowBind]]"
-                            even$="[[!_isEven(index)]]"
-                            row-detail-template="[[rowDetail]]"
-                            details-enabled="[[detailsEnabled]]"
-                            expanded="[[_isExpanded(item, _expandedItems)]]"
-                            on-item-expanded="_itemExpanded"
-                            on-item-collapsed="_itemCollapsed">
-              <data-table-checkbox hidden$="[[!multiSelection]]" checked="[[_isSelected(selected, selectedItems.inverted)]]"></data-table-checkbox>
+            <data-table-row tabindex$="[[tabIndex]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeRowBind]]" even$="[[!_isEven(index)]]" selected$="[[_isSelected(item, selectedItems, selectedItems.*)]]">
+              <data-table-checkbox hidden$="[[!multiSelection]]" checked="[[_isSelected(item, selectedItems, selectedItems.*)]]" on-tap="_onCheckBoxTap"></data-table-checkbox>
               <template is="dom-repeat" items="[[columns]]" as="column" index-as="colIndex">
-                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]" before-bind="[[beforeCellBind]]"></data-table-cell>
+                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeCellBind]]" on-tap="_onCellTap"></data-table-cell>
               </template>
               <template is="dom-if" if="[[_isExpanded(item, _expandedItems)]]" on-dom-change="_updateSizeForItem">
-                <data-table-row-detail row-detail-template="[[rowDetail]]" bind="[[_bind(item, index, selected, selectedItems.inverted, _expandedItems)]]"></data-table-row-detail>
+                <data-table-row-detail row-detail-template="[[rowDetail]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]"></data-table-row-detail>
               </template>
             </data-table-row>
           </div>
@@ -423,13 +411,13 @@ inspired styles to your `iron-data-table`.
         }
       },
 
-     /**
-      * Fired before row details is expanded/collapsed.
-      *
-      * @event iron-data-table-row-expanding
-      * @param {Object} detail.row the data-table-row element being tapped
-      * @param {Object} detail.target the target element of the original tap event
-      */
+      /**
+       * Fired before row details is expanded/collapsed.
+       *
+       * @event iron-data-table-row-expanding
+       * @param {Object} detail.row the data-table-row element being tapped
+       * @param {Object} detail.target the target element of the original tap event
+       */
 
       /**
        * Fired before row is selected/deselected.
@@ -442,7 +430,8 @@ inspired styles to your `iron-data-table`.
       observers: ['_itemsChanged(items.*)',
         '_sizeChanged(size)',
         '_currentPageChanged(dataSource, _currentPage)',
-        '_resetData(dataSource, filter.*, sortOrder.*)'
+        '_resetData(dataSource, filter.*, sortOrder.*)',
+        '_selectedItemsChanged(selectedItems.*)'
       ],
 
       created: function() {
@@ -469,7 +458,7 @@ inspired styles to your `iron-data-table`.
 
           var model = this.modelForElement(first);
           if (model) {
-              this.toggleSelectionForItem(model[this.as]);
+            this.toggleSelectionForItem(model[this.as]);
           }
         };
       },
@@ -485,32 +474,85 @@ inspired styles to your `iron-data-table`.
        * @param {(Object|number)} item The item object or its index
        */
       selectItem: function(item) {
-        if (this.selectedItems && this.selectedItems.inverted) {
-          this.$.list.deselectItem(item);
-        } else {
-          this.$.list.selectItem(item);
+        if (this.selectionEnabled) {
+          if (typeof item === 'number' && item >= 0 && this.items && this.items.length > item) {
+            this._selectItem(this.items[item]);
+          } else {
+            this._selectItem(item);
+          }
         }
       },
 
-      _isSelected: function(selected, inverted) {
-        return inverted ? !selected : selected;
+      _selectItem: function(item) {
+        this.selectedItem = item;
+
+        if (this.multiSelection) {
+          if (this.selectedItems.inverted) {
+            if ((index = this.selectedItems.indexOf(item)) > -1) {
+              this.splice('selectedItems', index, 1);
+            }
+          } else {
+            this.push('selectedItems', item);
+          }
+        } else {
+          this.splice('selectedItems', 0, this.selectedItems.length, item);
+        }
+      },
+
+      /**
+       * Deselects the given item list if it is already selected.
+       *
+       * @method deselect
+       * @param {(Object|number)} item The item object or its index
+       */
+      deselectItem: function(item) {
+        if (typeof item === 'number' && item >= 0 && this.items && this.items.length > item) {
+          this._deselectItem(this.items[item]);
+        } else {
+          this._deselectItem(item);
+        }
+      },
+
+      _deselectItem: function(item) {
+        this.selectedItem = null;
+
+        var index = this.selectedItems.indexOf(item);
+
+        if (this.selectedItems.inverted) {
+          if (index === -1) {
+            this.push('selectedItems', item);
+          }
+        } else {
+          if (index > -1) {
+            this.splice('selectedItems', index, 1);
+          }
+        }
+      },
+
+      _isSelected: function(item, selectedItems) {
+        var selected = selectedItems.indexOf(item) > -1;
+
+        return selectedItems.inverted ? !selected : selected;
       },
 
       /**
        * Multi-Selection
        */
       _selectedItemsChanged: function(e) {
-        if (Array.isArray(e.detail.value)) {
-          var items = e.detail.value;
-          var inverted = (this.selectedItems && this.selectedItems.inverted) || false;
+        if (e.path === 'selectedItems.splices') {
+          var splices = e.value.indexSplices[0];
 
-          this.set('selectedItems', items);
-          this.set('selectedItems.inverted', inverted);
-          this.notifyPath('selectedItems.length', items.length);
-          this.set('selectedItems.filters', this.filter || []);
-        } else if (e.detail.path === 'selectedItems.splices') {
-          this.notifyPath('selectedItems.splices', e.detail.value);
-          this.notifyPath('selectedItems.length', this.selectedItems.length);
+          Array.prototype.forEach.call(splices.object, function(item) {
+            this._templatesForItem(item).forEach(function(t) {
+              t.selected = e.base.inverted ? false : true;
+            });
+          }.bind(this));
+
+          Array.prototype.forEach.call(splices.removed, function(item) {
+            this._templatesForItem(item).forEach(function(t) {
+              t.selected = e.base.inverted ? true : false;
+            });
+          }.bind(this));
         }
       },
 
@@ -518,16 +560,22 @@ inspired styles to your `iron-data-table`.
        * Selects all the items in the list.
        */
       selectAll: function() {
-        this.set('selectedItems.inverted', true);
-        this.$.list.clearSelection();
+        var selectedItems = [];
+        selectedItems.inverted = true;
+        selectedItems.filters = this.filters;
+
+        this.set('selectedItems', selectedItems);
       },
 
       /**
        * Clears the current selection state.
        */
       clearSelection: function() {
-        this.set('selectedItems.inverted', false);
-        this.$.list.clearSelection();
+        var selectedItems = [];
+        selectedItems.inverted = false;
+        selectedItems.filters = this.filters;
+
+        this.set('selectedItems', selectedItems);
       },
 
       _toggleSelectAll: function() {
@@ -546,26 +594,13 @@ inspired styles to your `iron-data-table`.
         return selectedItemsLength > 0;
       },
 
-      /**
-       * Deselects the given item list if it is already selected.
-       *
-       * @method deselect
-       * @param {(Object|number)} item The item object or its index
-       */
-      deselectItem: function(item) {
-        if (this.selectedItems && this.selectedItems.inverted) {
-          this.$.list.selectItem(item);
-        } else {
-          this.$.list.deselectItem(item);
-        }
-      },
 
-      _bind: function(item, index, selected, inverted, expandedItems) {
-        if (index !== undefined && selected !== undefined) {
+      _bind: function(item, index, selectedItems, expandedItems) {
+        if (index !== undefined) {
           return {
             item: item,
             index: index,
-            selected: inverted ? !selected : selected,
+            selected: this._isSelected(item, selectedItems),
             // store expanded twice to detect changes coming from inside the template.
             __expanded__: this._isExpanded(item, expandedItems),
             expanded: this._isExpanded(item, expandedItems)
@@ -704,6 +739,18 @@ inspired styles to your `iron-data-table`.
         }
       },
 
+      _templatesForItem: function(item) {
+        return this.columns.map(function(col) {
+            return col._templateInstances;
+          })
+          .reduce(function(a, b) {
+            return a.concat(b);
+          }, [])
+          .filter(function(t) {
+            return t.item === item;
+          });
+      },
+
       _itemChanged: function(e) {
         if (this.items) {
           var index = this.items.indexOf(e.detail.item);
@@ -714,17 +761,13 @@ inspired styles to your `iron-data-table`.
       },
 
       _itemExpanded: function(e) {
-        var item = e.detail.item || e.model.item;
-
-        this.expandItem(item);
+        this.expandItem(e.detail.item);
       },
 
       _itemCollapsed: function(e) {
-        var item = e.detail.item || e.model.item;
-
-        this.collapseItem(item);
+        this.collapseItem(e.detail.item);
       },
-
+      
       _currentPageChanged: function(dataSource, page) {
         if (this._cachedPages && this._cachedPages.indexOf(page) === -1) {
           this.loading = true;
@@ -845,7 +888,7 @@ inspired styles to your `iron-data-table`.
       expandItem: function(item) {
         if (this.rowDetail && this._expandedItems && !this._isExpanded(item, this._expandedItems)) {
 
-          // replacing the whole array here to simplify the obsevers.
+          // replacing the whole array here to simplify the observers.
           this._expandedItems.push(item);
           this._expandedItems = this._expandedItems.slice(0);
         }
@@ -866,6 +909,34 @@ inspired styles to your `iron-data-table`.
 
       _isExpanded: function(item, items) {
         return items && items.indexOf(item) > -1;
+      },
+
+      _onCellTap: function(e) {
+        // Prevent item selection if row itself is not focused. This means that
+        // an element inside the row has been focused.
+        // Mobile devices don't move focus from body unless it's an input element that is focused, so this element will never get focused.
+        if (document.activeElement !== document.body &&
+            Polymer.dom(e).localTarget.contains(Polymer.dom(document.activeElement).node)) {
+          return;
+        } else {
+          if (this.rowDetail && this.detailsEnabled) {
+            if (this._isExpanded(e.model.item, this._expandedItems)) {
+              this.collapseItem(e.model.item);
+            } else {
+              this.expandItem(e.model.item);
+            }
+          }
+
+          if (this.selectionEnabled) {
+            this._isSelected(e.model.item, this.selectedItems) ? this.deselectItem(e.model.item) : this.selectItem(e.model.item);
+          }
+        }
+      },
+
+      _onCheckBoxTap: function(e) {
+        if (this.selectionEnabled) {
+          this._isSelected(e.model.item, this.selectedItems) ? this.deselectItem(e.model.item) : this.selectItem(e.model.item);
+        }
       }
     });
   </script>

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -180,10 +180,10 @@ inspired styles to your `iron-data-table`.
       <iron-list id="list" as="item" items="[[_cachedItems]]" on-scroll="_onVerticalScroll">
         <template>
           <div class="item">
-            <data-table-row tabindex$="[[tabIndex]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeRowBind]]" even$="[[!_isEven(index)]]" selected$="[[_isSelected(item, selectedItems, selectedItems.*)]]">
-              <data-table-checkbox hidden$="[[!multiSelection]]" checked="[[_isSelected(item, selectedItems, selectedItems.*)]]" on-tap="_onCheckBoxTap"></data-table-checkbox>
+            <data-table-row on-click="_onRowClick" tabindex$="[[tabIndex]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeRowBind]]" even$="[[!_isEven(index)]]" selected$="[[_isSelected(item, selectedItems, selectedItems.*)]]">
+              <data-table-checkbox hidden$="[[!multiSelection]]" tabindex="-1" checked="[[_isSelected(item, selectedItems, selectedItems.*)]]" on-tap="_onCheckBoxTap"></data-table-checkbox>
               <template is="dom-repeat" items="[[columns]]" as="column" index-as="colIndex">
-                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeCellBind]]" on-tap="_onCellTap"></data-table-cell>
+                <data-table-cell column="[[column]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]" before-bind="[[beforeCellBind]]"></data-table-cell>
               </template>
               <template is="dom-if" if="[[_isExpanded(item, _expandedItems)]]" on-dom-change="_updateSizeForItem">
                 <data-table-row-detail row-detail-template="[[rowDetail]]" bind="[[_bind(item, index, selectedItems, _expandedItems)]]"></data-table-row-detail>
@@ -907,7 +907,10 @@ inspired styles to your `iron-data-table`.
         return items && items.indexOf(item) > -1;
       },
 
-      _onCellTap: function(e) {
+      // we need to listen to click instead of tap because on mobile safari, the
+      // document.activeElement has not been updated (focus has not been shifted)
+      // yet at the point when tap event is being executed.
+      _onRowClick: function(e) {
         // Prevent item selection if row itself is not focused. This means that
         // an element inside the row has been focused.
         // Mobile devices don't move focus from body unless it's an input element that is focused, so this element will never get focused.

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -27,6 +27,8 @@ limitations under the License.
 <link rel="import" href="data-table-checkbox.html">
 <link rel="import" href="data-table-row-detail.html">
 
+<script src="array-datasource.js"></script>
+
 <!--
 `iron-data-table` displays a table or a grid of data.
 It builds on top of `iron-list`, which provides the foundation for features like
@@ -579,24 +581,6 @@ inspired styles to your `iron-data-table`.
         return index % 2 === 0;
       },
 
-      _filter: function(items, filter) {
-        if (filter.length === 0) {
-          return items;
-        }
-
-        return Array.prototype.filter.call(items, function(item, index) {
-          for (var i = 0; i < filter.length; i++) {
-            var value = this.get(filter[i].path, item);
-            if (!filter[i].filter) {
-              continue;
-            } else if (!value || value.toString().toLowerCase().indexOf(filter[i].filter.toString().toLowerCase()) === -1) {
-              return false;
-            }
-          }
-          return true;
-        }.bind(this));
-      },
-
       _resetData: function(dataSource, filter, sortOrder) {
         // Resetting scroll position and selection for consistency here. They are
         // both reset implicitly when a new _cachedItems is set to iron-list, but
@@ -607,30 +591,6 @@ inspired styles to your `iron-data-table`.
           this.clearCache();
           this.$.list.scrollToIndex(0);
         }.bind(this), 100);
-      },
-
-      _sort: function(items, sortOrder) {
-        if (!sortOrder || sortOrder.length === 0) {
-          return items;
-        }
-
-        var multiSort = function() {
-          return function(a, b) {
-            return sortOrder.map(function(sort) {
-              if (sort.direction === 'asc') {
-                return this._compare(this.get(sort.path, a), this.get(sort.path, b));
-              } else if (sort.direction === 'desc') {
-                return this._compare(this.get(sort.path, b), this.get(sort.path, a));
-              }
-              return 0;
-            }.bind(this)).reduce(function firstNonZeroValue(p, n) {
-                return p ? p : n;
-              }, 0);
-          };
-        };
-
-        // make sure a copy is used so that original array is unaffected.
-        return Array.prototype.sort.call(items.slice(0), multiSort(sortOrder).bind(this));
       },
 
       _sortDirectionChanged: function(e) {
@@ -649,16 +609,6 @@ inspired styles to your `iron-data-table`.
           path: e.detail.path,
           direction: e.detail.direction
         });
-      },
-
-      _compare: function(a, b) {
-        if (a < b) {
-          return -1;
-        }
-        if (a > b) {
-          return 1;
-        }
-        return 0;
       },
 
       _columnsChanged: function(columns, oldColumns) {
@@ -727,19 +677,7 @@ inspired styles to your `iron-data-table`.
       _itemsChanged: function(items) {
         if ((items.path === 'items' || items.path === 'items.splices') && Array.isArray(items.base)) {
           this.size = items.base.length;
-
-          this.dataSource = function(opts, cb, err) {
-            var filteredItems = this._filter(items.base, opts.filter);
-            this.size = filteredItems.length;
-
-            var sortedItems = this._sort(filteredItems, opts.sortOrder);
-
-            var start = opts.page * opts.pageSize;
-            var end = start + opts.pageSize;
-            var slice = sortedItems.slice(start, end);
-
-            cb(slice);
-          }.bind(this);
+          this.dataSource = new ArrayDataSource(items.base);
         } else if (items.path.indexOf('items.#') === 0 && Array.isArray(items.base)) {
           var index = items.path.split('.')[1].substring(1);
           var item = this.items[index];
@@ -810,7 +748,8 @@ inspired styles to your `iron-data-table`.
           this._pagesLoading++;
           this.push('_cachedPages', page);
 
-          var success = function(items) {
+          var success = function(items, size) {
+            this.size = size || this.size;
             var start = page * this.pageSize;
 
             for (var i = 0; i < this.pageSize; i++) {

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -304,6 +304,7 @@ inspired styles to your `iron-data-table`.
          */
         selectedItem: {
           type: Object,
+          readOnly: true,
           notify: true
         },
 
@@ -315,6 +316,7 @@ inspired styles to your `iron-data-table`.
         selectedItems: {
           type: Object,
           notify: true,
+          readOnly: true,
           value: function() {
             var items = [];
             items.filters = [];
@@ -350,6 +352,9 @@ inspired styles to your `iron-data-table`.
         columns: {
           type: Array,
           notify: true,
+          value: function() {
+            return [];
+          },
           observer: '_columnsChanged'
         },
 
@@ -484,7 +489,7 @@ inspired styles to your `iron-data-table`.
       },
 
       _selectItem: function(item) {
-        this.selectedItem = item;
+        this._setSelectedItem(item);
 
         if (this.multiSelection) {
           if (this.selectedItems.inverted) {
@@ -514,7 +519,7 @@ inspired styles to your `iron-data-table`.
       },
 
       _deselectItem: function(item) {
-        this.selectedItem = null;
+        this._setSelectedItem(null);
 
         var index = this.selectedItems.indexOf(item);
 
@@ -564,7 +569,7 @@ inspired styles to your `iron-data-table`.
         selectedItems.inverted = true;
         selectedItems.filters = this.filters;
 
-        this.set('selectedItems', selectedItems);
+        this._setSelectedItems(selectedItems);
       },
 
       /**
@@ -575,7 +580,7 @@ inspired styles to your `iron-data-table`.
         selectedItems.inverted = false;
         selectedItems.filters = this.filters;
 
-        this.set('selectedItems', selectedItems);
+        this._setSelectedItems(selectedItems);
       },
 
       _toggleSelectAll: function() {
@@ -767,7 +772,7 @@ inspired styles to your `iron-data-table`.
       _itemCollapsed: function(e) {
         this.collapseItem(e.detail.item);
       },
-      
+
       _currentPageChanged: function(dataSource, page) {
         if (this._cachedPages && this._cachedPages.indexOf(page) === -1) {
           this.loading = true;
@@ -800,15 +805,6 @@ inspired styles to your `iron-data-table`.
               var item = items[i];
 
               this.set('_cachedItems.' + index, item);
-
-              // TODO: send an issue/pr to iron-list, that makes sure the internal
-              // collection stays up-to-date when `items` change.
-              this.$.list._collection.store[index] = item;
-              if (item && typeof item == 'object') {
-                this.$.list._collection.omap.set(item, index);
-              } else {
-                this.$.list._collection.pmap[item] = index;
-              }
             }
 
             // resize required for variable row height items.

--- a/test/selecting.html
+++ b/test/selecting.html
@@ -8,6 +8,7 @@
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
   <link rel="import" href="../iron-data-table.html">
+  <link rel="import" href="../../vaadin-combo-box/vaadin-combo-box.html">
 </head>
 
 <body>
@@ -27,7 +28,273 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="table">
+    <template>
+      <iron-data-table selection-enabled>
+        <template is="row-details">
+          <div>[[selected]]</div>
+          <vaadin-combo-box items="[[items]]" selectedItem="{{selected}}"></vaadin-combo-box>
+        </template>
+        <data-table-column name="First">
+          <template>
+            <value-helper id="first" value="[[selected]]"></value-helper>
+          </template>
+        </data-table-column>
+        <data-table-column name="Second">
+          <template>
+            <value-helper id="second" value="[[selected]]"></value-helper>
+            <input id="input" type="text"></input>
+          </template>
+        </data-table-column>
+      </iron-data-table>
+    </template>
+  </test-fixture>
+
+  <dom-module id="value-helper">
+    <template>
+      <style>
+        :host {
+          display: block;
+        }
+      </style>
+      <div>[[value]]</div>
+    </template>
+    <script>
+      Polymer({
+        is: 'value-helper',
+
+        properties: {
+          value: {
+            type: Object,
+            notify: true
+          }
+        }
+      });
+    </script>
+  </dom-module>
+
   <script>
+    describe('selecting items', function() {
+      var table;
+      var first, second, input;
+
+      function tap(node) {
+        Polymer.Base.fire('tap', null, {
+          node: node
+        });
+      }
+
+      function waitUntil(fn, done) {
+        setTimeout(function() {
+          if (!fn()) {
+            waitUntil(fn, done);
+          } else {
+            done();
+          }
+        }, 10);
+      }
+
+      beforeEach(function(done) {
+        table = fixture('table');
+        table.items = ['foo', 'bar', 'baz'];
+        first = table.querySelector("#first");
+        second = table.querySelector("#second");
+        input = table.querySelector("#input");
+
+        //100ms to take into account the debounce on _loadPage.
+        table.async(done, 100);
+      });
+
+      function assertSelected(selected) {
+        expect(table.selectedItem).to.eql(selected);
+      }
+
+      describe('by using select functions', function() {
+        it('should update selectedItem(s) on select', function() {
+          table.selectItem('foo');
+
+          expect(table.selectedItem).to.eql('foo');
+          expect(table.selectedItems).to.have.members(['foo']);
+        });
+
+        it('should fire `selected-item-changed`', function(done) {
+          table.addEventListener('selected-item-changed', function(e) {
+            expect(e.detail.value).to.eql('foo');
+
+            done();
+          });
+
+          table.selectItem('foo');
+        });
+
+        it('should fire `selected-items-changed`', function(done) {
+          table.addEventListener('selected-items-changed', function(e) {
+            expect(e.detail.value.indexSplices[0].object[0]).to.eql('foo');
+
+            done();
+          });
+
+          table.selectItem('foo');
+        });
+
+        it('should update selectedItem(s) on second select', function() {
+          table.selectItem('foo');
+          table.selectItem('bar');
+
+          expect(table.selectedItem).to.eql('bar');
+          expect(table.selectedItems).to.have.members(['bar']);
+        });
+
+        it('should update selectedItem(s) on deselect', function() {
+          table.selectItem('foo');
+          table.deselectItem('foo');
+
+          expect(table.selectedItem).to.be.null;
+          expect(table.selectedItems).to.have.members([]);
+        });
+
+        it('should update selectedItem also on invalid deselect', function() {
+          table.selectItem('foo');
+          table.deselectItem('bar');
+
+          expect(table.selectedItem).to.be.null;
+          expect(table.selectedItems).to.have.members(['foo']);
+        });
+
+        it('should update [[selected]] on select', function(done) {
+          first.addEventListener('value-changed', function(e) {
+            expect(e.detail.value).to.eql(true);
+            done();
+          });
+
+          table.selectItem('foo');
+        });
+
+        it('should update [[selected]] on deselect', function(done) {
+          table.selectItem('foo');
+
+          first.addEventListener('value-changed', function(e) {
+            expect(e.detail.value).to.eql(false);
+            done();
+          });
+
+          table.deselectItem('foo');
+        });
+
+        describe('multi-select', function() {
+          beforeEach(function() {
+            table.multiSelection = true;
+          });
+
+          it('should update selectedItems on multiple select', function() {
+            table.selectItem('foo');
+            table.selectItem('bar');
+
+            expect(table.selectedItems).to.have.members(['foo', 'bar']);
+          });
+
+          it('should update selectedItems on deselect', function() {
+            table.selectItem('foo');
+            table.selectItem('bar');
+            table.deselectItem('foo');
+
+            expect(table.selectedItems).to.have.members(['bar']);
+          });
+        });
+      });
+
+      describe('by tapping on rows', function() {
+        it('should not select row when selection-enabled is false', function(done) {
+          table.selectionEnabled = false;
+
+          first.addEventListener('value-changed', function(e) {
+            done(new Error('Value should not change.'));
+          });
+
+          tap(first);
+
+          setTimeout(done, 250);
+        });
+
+        it('should select row when tapping', function(done) {
+          first.addEventListener('value-changed', function(e) {
+            expect(e.detail.value).to.eql(true);
+            done();
+          });
+
+          tap(first);
+        });
+
+        it('should deselect row when tapping again', function(done) {
+          tap(first);
+
+          first.addEventListener('value-changed', function(e) {
+            expect(e.detail.value).to.eql(false);
+            done();
+          });
+
+          tap(first);
+        });
+
+        // can't be tested reliably because focus can't be trusted when testing.
+        it.skip('should not select row when tapping on focusable child', function(done) {
+          tap(first);
+
+          var spy = sinon.spy();
+          first.addEventListener('value-changed', spy);
+
+          tap(input);
+
+          table.async(function() {
+            debugger;
+            expect(spy.callCount).to.eql(0);
+            done();
+          }, 250);
+        });
+
+        it('should update selectedItem(s)', function(done) {
+          first.addEventListener('value-changed', function(e) {
+            expect(table.selectedItem).to.eql('foo');
+            expect(table.selectedItems).to.have.members(['foo']);
+
+            done();
+          });
+
+          tap(first);
+        });
+        it('should update [[selected]] on template instances', function(done) {
+          second.addEventListener('value-changed', function(e) {
+            expect(e.detail.value).to.eql(true);
+            done();
+          });
+
+          tap(first);
+        });
+      });
+
+      describe('using two-way binding', function() {
+        it('should update [[selected]] on template instances with the same item', function() {
+          input.value = 'foo';
+
+          expect(first.innerHTML).to.eql('true');
+          expect(second.innerHTML).to.eql('true');
+        });
+
+        it('should update selectedItem(s)', function() {
+          input.value = 'bar';
+
+          expect(table.selectedItem).to.eql('bar');
+          expect(table.selectedItems).to.have.members(['bar']);
+        });
+      });
+
+      describe('using data-table-row selected property', function() {});
+
+      describe('using data-table-row selected attribute', function() {}
+
+      );
+    });
+
     describe('Selecting', function() {
       var grid;
       beforeEach(function(done) {


### PR DESCRIPTION
Fixes #32 
Fixes #63
Closes #31 

Notes:
- `selectedItem` and `selectedItems` now `readonly` (which they effectively were also before)
- the primitive keyboard navigation used through `iron-list` can't select rows anymore
- tests incomplete

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/71)

<!-- Reviewable:end -->
