### PR TITLE
Update iron-data-table.html to reflect behavior namespacing

### DIFF
--- a/detect-scrollbar-behavior.html
+++ b/detect-scrollbar-behavior.html
@@ -10,12 +10,14 @@
 </style>
 
 <script>
+  var vaadin = window.vaadin || {};
+  
   /**
    * Use `DetectScrollBarBehavior` to detect scrollbar width.
    *
    * @polymerBehavior
    */
-  DetectScrollBarBehavior = {
+  vaadin.DetectScrollBarBehavior = {
     properties: {
       /**
        * Automatically detected scroll bar width in px.


### PR DESCRIPTION
I'm trying to use iron-data-table in an a compiled environment where the compiler is complaining that the behavior is declared in the global namespace. Would be great if we could define a namespace for the behavior!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/84)

<!-- Reviewable:end -->
