### PR TITLE
Move paper-input margin to container mixin for easier styling

### DIFF
--- a/data-table-column-filter.html
+++ b/data-table-column-filter.html
@@ -7,7 +7,9 @@
     }
 
     paper-input {
-      margin-bottom: 20px;
+      --paper-input-container: {
+        margin-bottom: 20px;
+      };
       --paper-input-container-label: {
         font-size: inherit;
       }

--- a/demo/templates.html
+++ b/demo/templates.html
@@ -85,7 +85,9 @@
         <template is="dom-bind">
           <style is="custom-style">
             paper-input {
-              margin-bottom: 20px;
+              --paper-input-container: {
+                margin-bottom: 20px;
+              };
               --paper-input-container-label: {
                 font-size: inherit;
               }


### PR DESCRIPTION
There should be an opportunity to configure this `margin-bottom` value using CSS mixin. 
In general, `paper-input-container` should be used to style filter input, not just the `paper-input` itself.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/95)

<!-- Reviewable:end -->
