### PR TITLE
Add behavior annotations

### DIFF
--- a/data-table-templatizer-behavior.html
+++ b/data-table-templatizer-behavior.html
@@ -1,6 +1,7 @@
 <script>
   var saulis = window.saulis || {};
 
+  /* @polymerBehavior */
   saulis.DataTableTemplatizerBehaviorImpl = {
     properties: {
       expanded: Boolean,
@@ -141,6 +142,7 @@
     }
   };
 
+  /* @polymerBehavior */
   saulis.DataTableTemplatizerBehavior =
     [Polymer.Templatizer, saulis.DataTableTemplatizerBehaviorImpl];
 </script>

--- a/data-table-templatizer-behavior.html
+++ b/data-table-templatizer-behavior.html
@@ -1,7 +1,7 @@
 <script>
   var saulis = window.saulis || {};
 
-  /* @polymerBehavior */
+  /** @polymerBehavior */
   saulis.DataTableTemplatizerBehaviorImpl = {
     properties: {
       expanded: Boolean,
@@ -142,7 +142,7 @@
     }
   };
 
-  /* @polymerBehavior */
+  /** @polymerBehavior */
   saulis.DataTableTemplatizerBehavior =
     [Polymer.Templatizer, saulis.DataTableTemplatizerBehaviorImpl];
 </script>


### PR DESCRIPTION
Add comments to prevent build warnings:

```
Behavior saulis.DataTableTemplatizerBehavior not found when mixing properties into data-table-row-detail!
Behavior saulis.DataTableTemplatizerBehavior not found when mixing properties into data-table-cell!
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/104)

<!-- Reviewable:end -->
