### PR TITLE
Fix select all checkbox is checked when the items is an empty array

### DIFF
--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -606,7 +606,7 @@ inspired styles to your `iron-data-table`.
       },
 
       _isSelectAllChecked: function(selectedItemsLength, inverted) {
-        return selectedItemsLength === (inverted ? 0 : this.size);
+        return selectedItemsLength === (inverted ? 0 : this.size ? this.size : -1);
       },
 
       _isSelectAllIndeterminate: function(selectedItemsLength) {


### PR DESCRIPTION
When the items is set as an empty array [] , the select all checkbox is automatically checked.
This line may be the issue

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/110)

<!-- Reviewable:end -->
