### PR TITLE
Consistency "PolymerElements" vs "polymerelements" in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,27 +33,27 @@
   ],
   "dependencies": {
     "polymer": "^1.2.4",
-    "iron-list": "polymerelements/iron-list#^1.2.0",
-    "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.2",
-    "paper-input": "polymerelements/paper-input#^1.1.5",
-    "paper-spinner": "polymerelements/paper-spinner#^1.1.1",
-    "paper-icon-button": "polymerelements/paper-icon-button#^1.0.7",
-    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.9"
+    "iron-list": "PolymerElements/iron-list#^1.2.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.2",
+    "paper-input": "PolymerElements/paper-input#^1.1.5",
+    "paper-spinner": "PolymerElements/paper-spinner#^1.1.1",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.7",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9"
   },
   "devDependencies": {
     "webcomponentsjs": "^0.7.20",
-    "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.0.3",
-    "paper-checkbox": "polymerelements/paper-checkbox#^1.1.0",
-    "paper-button": "polymerelements/paper-button#^1.0.11",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.3",
+    "paper-checkbox": "PolymerElements/paper-checkbox#^1.1.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.11",
     "web-component-tester": "^4.2.0",
-    "test-fixture": "polymerelements/test-fixture#^1.1.0",
-    "iron-test-helpers": "polymerelements/iron-test-helpers#^1.1.3",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.2.3",
-    "iron-component-page": "polymerelements/iron-component-page#^1.1.4",
-    "iron-ajax": "polymerelements/iron-ajax#^1.1.1",
-    "iron-icons": "polymerelements/iron-icons#^1.1.3",
+    "test-fixture": "PolymerElements/test-fixture#^1.1.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.3",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.2.3",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1.4",
+    "iron-ajax": "PolymerElements/iron-ajax#^1.1.1",
+    "iron-icons": "PolymerElements/iron-icons#^1.1.3",
     "vaadin-combo-box": "^1.0.0-beta1",
-    "paper-slider": "polymerelements/paper-slider#^1.0.9"
+    "paper-slider": "PolymerElements/paper-slider#^1.0.9"
   },
   "resolutions": {
     "iron-list": "^1.1.0"


### PR DESCRIPTION
for webjars usage.
This closes issue #130

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/131)

<!-- Reviewable:end -->
