### PR TITLE
Make all tagName comparisons case-insensitive.

### DIFF
--- a/data-table-row.html
+++ b/data-table-row.html
@@ -80,7 +80,7 @@
       observers: ['_beforeBind(beforeBind, index, item.*, selected, expanded)'],
 
       attached: function() {
-        if (this.domHost && this.domHost.tagName === 'IRON-DATA-TABLE') {
+        if (this.domHost && this.domHost.tagName.toUpperCase() === 'IRON-DATA-TABLE') {
           var id = this._static.id++;
 
           var item = this.parentElement;

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -473,12 +473,12 @@ inspired styles to your `iron-data-table`.
       created: function() {
         this._observer = Polymer.dom(this).observeNodes(function(info) {
           var hasColumns = function(node) {
-            return (node.nodeType === Node.ELEMENT_NODE && node.tagName === 'DATA-TABLE-COLUMN');
+            return (node.nodeType === Node.ELEMENT_NODE && node.tagName.toUpperCase() === 'DATA-TABLE-COLUMN');
           };
 
           var hasDetails = function(node) {
             return (node.nodeType === Node.ELEMENT_NODE &&
-              node.tagName === 'TEMPLATE' && node.hasAttribute('is') &&
+              node.tagName.toUpperCase() === 'TEMPLATE' && node.hasAttribute('is') &&
               node.getAttribute('is') === 'row-detail');
           };
 
@@ -907,7 +907,7 @@ inspired styles to your `iron-data-table`.
         } else {
           // unreliable with Shadow, document.activeElement doesn't go inside
           // the shadow root.
-          return target.contains(Polymer.dom(document.activeElement).node) || target.tagName === 'A';
+          return target.contains(Polymer.dom(document.activeElement).node) || target.tagName.toUpperCase() === 'A';
         }
       },
 


### PR DESCRIPTION
This allows iron-data-table to be used on XHTML documents, where tag names are
case-sensitive.

Per https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName:
"""In XHTML (or any other XML format), "span" would be output. In HTML, "SPAN"
would be output instead."""

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/139)

<!-- Reviewable:end -->
