### PR TITLE
Add missing import to <data-table-row-detail> component

### DIFF
--- a/data-table-row-detail.html
+++ b/data-table-row-detail.html
@@ -1,3 +1,5 @@
+<link rel="import" href="data-table-templatizer-behavior.html">
+
 <dom-module id="data-table-row-detail">
   <template>
     <style>


### PR DESCRIPTION
Necessary for non-vulcanized environments

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/156)

<!-- Reviewable:end -->
