### PR TITLE
Option to disable multiSorting

### DIFF
--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -308,6 +308,15 @@ inspired styles to your `iron-data-table`.
         },
 
         /**
+         * When `false`, items may be sorted by many collumns at once.
+         * When `true`, items may be sorted only by one collumn.
+         */
+        disableMultiSort: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * An array containing path/filter value pairs that are used to filter the items
          */
         filter: {
@@ -324,15 +333,6 @@ inspired styles to your `iron-data-table`.
          * only one item may be selected at a time.
          */
         multiSelection: {
-          type: Boolean,
-          value: false
-        },
-
-        /**
-         * When `false`, items may be sorted by many collumns at once.
-         * When `true`, items may be sorted only by one collumn.
-         */
-        disableMultiSort: {
           type: Boolean,
           value: false
         },

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -329,6 +329,15 @@ inspired styles to your `iron-data-table`.
         },
 
         /**
+         * When `false`, items may be sorted by many collumns at once.
+         * When `true`, items may be sorted only by one collumn.
+         */
+        disableMultiSort: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * Number of items fetched at a time from the datasource.
          */
         pageSize: {
@@ -648,6 +657,18 @@ inspired styles to your `iron-data-table`.
             }
             return;
           }
+        }
+
+        // disable multiSorting
+        if(this.disableMultiSort && this.sortOrder.length) {
+          // clear currently selected column
+          this.set('sortOrder.0.direction', null);
+
+          this.set('sortOrder', [{
+            path: e.detail.path,
+            direction: e.detail.direction
+          }]);
+          return;
         }
 
         this.push('sortOrder', {


### PR DESCRIPTION
Sometimes you may need to disable multisorting, by this change it's possible and items can be sorted only by one column.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/175)
<!-- Reviewable:end -->
