### PR TITLE
Add CSS variables for cell height

### DIFF
--- a/data-table-cell.html
+++ b/data-table-cell.html
@@ -7,7 +7,7 @@
         flex: 1 0 100px;
         padding: 0 24px 0 24px;
         min-height: 10px; /* Prevent iron-list from looping when item height is really small */
-        height: 48px;
+        height: var(--data-table-cell-height, 48px);
         display: flex;
         align-items: center;
         overflow: hidden;
@@ -15,7 +15,7 @@
       }
 
       :host([header]) {
-        height: 56px;
+        height: var(--data-table-cell-header-height, 56px);
       }
 
       :host([hidden]) {

--- a/data-table-checkbox.html
+++ b/data-table-checkbox.html
@@ -2,7 +2,7 @@
   <template>
     <style>
       :host {
-        height: 48px;
+        height: var(--data-table-cell-height, 48px);
         flex-basis: 48px;
         flex-grow: 0;
         flex-shrink: 0;
@@ -14,7 +14,7 @@
       }
 
       :host([header]) {
-        height: 56px;
+        height: var(--data-table-cell-header-height, 56px);
       }
 
       :host([hidden]) {


### PR DESCRIPTION
This is the same as https://github.com/Saulis/iron-data-table/pull/165 except that it also applies the variables to data-table-checkbox, which is required in order to make the table work when multiSelect is enabled.

The reason this is necessary is because normal CSS selectors such as the following don't work with the Shadow DOM, i.e. it breaks in any browser which implements web components without a polyfill.
```
iron-data-table data-table-cell {
  height: 100px;
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/177)
<!-- Reviewable:end -->
