### PR TITLE
added filter method support

### DIFF
--- a/array-datasource.js
+++ b/array-datasource.js
@@ -6,7 +6,12 @@ function ArrayDataSource(arr) {
 
     return Array.prototype.filter.call(items, function(item, index) {
       for (var i = 0; i < filter.length; i++) {
-        var value = Polymer.Base.get(filter[i].path, item);
+			if(filter[i].method) {
+				if(filter[i].method(item, index, items)) continue;
+				else return false;
+			}
+			if(!filter[i].path) continue;
+		  var value = Polymer.Base.get(filter[i].path, item);
         if ([undefined, null, ''].indexOf(filter[i].filter) > -1) {
           continue;
         } else if ([undefined, null].indexOf(value) > -1 ||

--- a/data-table-column.html
+++ b/data-table-column.html
@@ -41,6 +41,13 @@
         filterValue: String,
 
         /**
+         * Filter is a function or the name of a function of the host. This is similar
+			* to the filter property of Polymer's dom-repeat
+			* (https://www.polymer-project.org/1.0/docs/api/dom-repeat)
+         */
+		  filter: {},
+
+        /**
          * Minimum width of the column
          */
         width: {
@@ -129,8 +136,9 @@
 
       observers: [
         '_alignRightChanged(table, alignRight)',
-        '_filterValueChanged(table, filterValue, filterBy)',
+        '_filterChanged(table, filter)',
         '_filterByChanged(table, filterBy)',
+        '_filterValueChanged(table, filterValue)',
         '_flexChanged(table, flex)',
         '_headerTemplateChanged(table, headerTemplate)',
         '_hiddenChanged(table, hidden)',
@@ -186,11 +194,30 @@
 
       _filterByChanged: function(table, filterBy) {
         this._notifyTable(table, 'filterBy', filterBy);
+		  this._columnFilterChanged();
       },
 
-      _filterValueChanged: function(table, filterValue, filterBy) {
+      _filterValueChanged: function(table, filterValue) {
         this._notifyTable(table, 'filterValue', filterValue);
-        this.fire('column-filter-changed', {value: filterValue, filterBy: filterBy});
+		  this._columnFilterChanged();
+      },
+
+      _filterChanged: function(table, filter) {
+        this._notifyTable(table, 'filter', filter);
+		  this._columnFilterChanged();
+      },
+
+      _columnFilterChanged: function(table, filter, filterValue, filterBy) {
+			var siblings = this.parentNode.childNodes, idx;
+			for(var i = 0; i < siblings.length; i++) {
+				if(siblings[i] === this) idx = i;
+			}
+        this.fire('column-filter-changed', {
+			  index:idx,
+			  filter:this.filter,
+			  value: this.filterValue,
+			  filterBy: this.filterBy
+		  });
       }
     });
   </script>

--- a/iron-data-table.html
+++ b/iron-data-table.html
@@ -659,6 +659,7 @@ inspired styles to your `iron-data-table`.
       _columnsChanged: function(columns, oldColumns) {
         if (oldColumns) {
           oldColumns.forEach(function(column) {
+            this.unlisten(column, 'column-filter-changed');
             this.unlisten(column, 'filter-value-changed');
           }.bind(this));
         }
@@ -666,32 +667,32 @@ inspired styles to your `iron-data-table`.
         if (columns) {
           columns.forEach(function(column) {
             column.table = this;
-            this.listen(column, 'filter-value-changed', '_onColumnFilterChanged');
+            this.listen(column, 'column-filter-changed', '_onColumnFilterChanged');
           }.bind(this));
         }
       },
 
       _onColumnFilterChanged: function(e) {
+        var filter = {
+			  index:e.detail.index,
+			  method: (typeof(e.detail.filter) === "string") ? this.domHost[e.detail.filter] : e.detail.filter,
+			  filter:e.detail.value,
+			  path: e.detail.filterBy
+		  };
         for (var i = 0; i < this.filter.length; i++) {
-          if (this.filter[i].path === e.detail.filterBy) {
-            this.set('filter.' + i + '.filter', e.detail.value);
+          if (this.filter[i].index === e.detail.index) {
+            this.set('filter.' + i, filter);
 
             // selectedItems.filter is actually already set at this point when
             // clearSelection is called after filter is set.
-            this.set('selectedItems.filters.' + i + '.filter', e.detail.value);
+            this.set('selectedItems.filters.' + i, filter);
             return;
           }
         }
 
-        this.push('filter', {
-          path: e.detail.filterBy,
-          filter: e.detail.value
-        });
+        this.push('filter', filter);
 
-        this.push('selectedItems.filters', {
-          path: e.detail.filterBy,
-          filter: e.detail.value
-        });
+        this.push('selectedItems.filters', filter);
       },
 
       _resizeCellContainers: function() {


### PR DESCRIPTION
Hi there

I added support for generic filter functions. My use-case:

The user can select multiple criteria from a drop-down in the header. Items are kept if they match any of these criteria (OR). This is just what I needed, though. The implementation in iron-data-table is generic and can be used for any complex filter task like combining  filters from several columns or whatever.

I tried to touch as little of the existing code as possible, however, I needed to change the way filters are indexed because filter-functions do not have a filterBy property (it's not required and potentially makes the usage of filter functions more difficult for client programmers if it were) which was used as a key for filters. This may change the behavior where client programmers did unhealthy things like using the same filterBy in multiple columns.

I modeled the feature after the "filter" property of Polymer's dom-repeat.

Ugh, and thanks for that great table, love it :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saulis/iron-data-table/196)
<!-- Reviewable:end -->
